### PR TITLE
Reduce cache size on iOS

### DIFF
--- a/src/source/source_cache.js
+++ b/src/source/source_cache.js
@@ -291,7 +291,12 @@ class SourceCache extends Evented {
         const heightInTiles = Math.ceil(transform.height / transform.tileSize) + 1;
         const approxTilesInView = widthInTiles * heightInTiles;
         const commonZoomRange = 5;
-        this._cache.setMaxSize(Math.floor(approxTilesInView * commonZoomRange));
+        const idealSize = Math.floor(approxTilesInView * commonZoomRange);
+        const ios = /iP(hone|od|ad)/.test(navigator.userAgent);
+
+        // Constrain cache on iOS devices
+        const maxSize = ios ? 8 : idealSize;
+        this._cache.setMaxSize(maxSize);
     }
 
     /**


### PR DESCRIPTION
Safari on iOS aggressively limits the memory use causing hard page
reloads. Code taken from
https://github.com/mapbox/mapbox-gl-js/issues/4052