### PR TITLE
Accumulates highlighted state in superclusters

### DIFF
--- a/src/source/geojson_worker_source.js
+++ b/src/source/geojson_worker_source.js
@@ -140,7 +140,11 @@ class GeoJSONWorkerSource extends VectorTileWorkerSource {
                         accumulated.markerids = ids;
                     } else {
                         accumulated.markerids = ids.concat(props.id);
-                    }
+                    };
+
+                    if (props.highlighted === true) {
+                        accumulated.highlighted = true;
+                    };
                 };
 
                 callback(null, supercluster(params.superclusterOptions).load(data.features));


### PR DESCRIPTION
In the supercluster reduce function, propagate `highlighted: true` state if the props are `highlighted: true`